### PR TITLE
fix read for install directory location

### DIFF
--- a/install_script.sh
+++ b/install_script.sh
@@ -108,9 +108,9 @@ fi
 # check for install directory specification 
 if [ -z "$1" ]
 then 
-  echo "You did not set an installtion directory.  Please type an install directory..."
-  read input
-  installDirectory=input
+  echo "You did not set an installtion directory"
+  read -p "Please set a location or use the default provided: " -ei "$HOME/developerlevel" installDirectory
+  echo "install directory: $installDirectory"
 fi 
 
 # if there is no directory, make one 


### PR DESCRIPTION
if the user puts does not specify an install directory when calling the script, the install script will now prompt for an install directory and provide a default value for the user if they do not wish to provide one.

ref: Issue #3